### PR TITLE
Add top 5 CPU/memory consuming systemd services

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -228,17 +228,42 @@ class TestApplication(testlib.MachineCase):
             m = re.search("width: (\d+)%;", style)
             return int(m.group(1))
 
+        def topServiceValue(aria_label, col_label, row):
+            sel = "table[aria-label='%s'] tbody tr:nth-of-type(%d) td[data-label='%s']" % (aria_label, row, col_label)
+            # split off unit, like "12 MB"
+            return float(b.text(sel).split(' ')[0])
+
+        # cgroups metrics require cgroup v1 or cockpit >= 227
+        has_cgroups_metrics = m.image not in ['fedora-32']
+
         # CPU
 
         nproc = m.execute("nproc").strip()
         b.wait_in_text("#current-cpu-usage", nproc + " CPU")
         # wait until system settles down
         b.wait(lambda: progressValue("#current-cpu-usage") < 20)
-        m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done", "cpu_hog.log")
+        m.execute("systemd-run -p CPUQuota=60% --unit cpu-hog.service dd if=/dev/urandom of=/dev/null")
+        m.execute("systemd-run -p CPUQuota=30% --unit cpu-piglet.service dd if=/dev/urandom of=/dev/null")
+        # make sure to clean up on failures
+        self.addCleanup(m.execute, "systemctl stop cpu-hog.service cpu-piglet.service 2>/dev/null || true")
         b.wait(lambda: progressValue("#current-cpu-usage") > 75)
-        m.execute("pkill -e -f cat.*urandom")
+        if has_cgroups_metrics:
+            # no other process in the test VM should take > 30% CPU, by the "settles down" assertion above
+            b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(1) td[data-label='Service']", "cpu-hog")
+            b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(2) td[data-label='Service']", "cpu-piglet")
+            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) > 50)
+            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) < 70)
+            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) > 20)
+            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) < 40)
+        else:
+            b.wait_not_present("table[aria-label='Top 5 CPU services']")
+
+        m.execute("systemctl stop cpu-hog.service cpu-piglet.service")
         # should go back to idle usage
         b.wait(lambda: progressValue("#current-cpu-usage") < 20)
+        if has_cgroups_metrics:
+            b.wait_not_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-hog")
+            b.wait_not_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-piglet")
 
         # Load looks like "1 min: 1.41, 5 min: 1.47, 15 min: 2.30"
         b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) < 5)
@@ -258,21 +283,43 @@ class TestApplication(testlib.MachineCase):
         self.assertLess(initial_usage, 80)
         # allocate an extra 300 MB; this may cause other stuff to get unmapped,
         # thus not exact addition, but usage should go up
-        mem_hog = m.spawn("MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); touch /tmp/hogged; sleep infinity", "mem_hog.log")
+        m.execute("systemd-run --unit mem-hog.service sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); touch /tmp/hogged; sleep infinity'")
+        # make sure to clean up on failures
+        self.addCleanup(m.execute, "systemctl stop mem-hog.service 2>/dev/null || true")
         m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
         # bars update every 3s
         time.sleep(8)
         hog_usage = progressValue("#current-memory-usage")
         self.assertGreater(hog_usage, initial_usage + 8)
 
-        # use even more to trigger swap
-        mem_hog2 = m.spawn("MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity", "mem_hog2.log")
+        if has_cgroups_metrics:
+            b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
+            b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) > 300)
+            b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) < 350)
+
+            # table entries are links to Services page
+            b.click("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service'] a")
+            b.enter_page("/system/services")
+            b.wait_in_text("#path", "/mem-hog.service")
+            b.wait_in_text(".service-name", "MEMBLOB=")
+
+            b.go("/performance-graphs")
+            b.enter_page("/performance-graphs")
+            b.wait_present("table[aria-label='Top 5 memory services']")
+        else:
+            b.wait_not_present("table[aria-label='Top 5 memory services']")
+
+        # use even more memory to trigger swap
+        m.execute("systemd-run --unit mem-hog2.service sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity'")
         b.wait(lambda: progressValue("#current-swap-usage") > 0)
 
-        m.execute("kill %d %d" % (mem_hog, mem_hog2))
+        m.execute("systemctl stop mem-hog.service mem-hog2.service")
+
         # should go back to initial_usage; often below, due to paged out stuff
         b.wait(lambda: progressValue("#current-memory-usage") <= initial_usage)
         self.assertGreater(progressValue("#current-memory-usage"), 10)
+        if has_cgroups_metrics:
+            b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
 
         # Disk I/O
 


### PR DESCRIPTION
Split the first card into separate CPU and Memory cards for that. This
also makes the cards nicely symmetric to the graphs now -- one card per
graph.

On my system (no swap):

![image](https://user-images.githubusercontent.com/200109/92436944-26709900-f1a6-11ea-8f8e-cc7806bfb200.png)

On F33 VM with swap:

![image](https://user-images.githubusercontent.com/200109/92437318-e958d680-f1a6-11ea-96c2-42dc24bae54f.png)

## TODO

- [x] turn table service names into links
- [x] integration tests