### PR TITLE
Fix application CSS

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -30,7 +30,6 @@ import {
 } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant, RowWrapper } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import './app.scss';
 
 import * as machine_info from "../lib/machine-info.js";
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ import { Application } from './app.jsx';
  * the overrides will be correctly in the end of our stylesheet.
  */
 import "./lib/patternfly-4-overrides.scss";
+import './app.scss';
 
 document.addEventListener("DOMContentLoaded", function () {
     ReactDOM.render(React.createElement(Application, {}), document.getElementById('app'));


### PR DESCRIPTION
Import our application CSS as the very last thing, so that it can
properly override  PatternFly variables. Before, our application CSS
landed in the first third of dist/index.css *before* PatternFly's
definitions, so that the latter overrode the former.

Fixes #10