### PR TITLE
test: Drop special case for cgroup metrics

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -233,9 +233,6 @@ class TestApplication(testlib.MachineCase):
             # split off unit, like "12 MB"
             return float(b.text(sel).split(' ')[0])
 
-        # cgroups metrics require cgroup v1 or cockpit >= 227
-        has_cgroups_metrics = m.image not in ['fedora-32']
-
         # CPU
 
         nproc = m.execute("nproc").strip()
@@ -247,23 +244,19 @@ class TestApplication(testlib.MachineCase):
         # make sure to clean up on failures
         self.addCleanup(m.execute, "systemctl stop cpu-hog.service cpu-piglet.service 2>/dev/null || true")
         b.wait(lambda: progressValue("#current-cpu-usage") > 75)
-        if has_cgroups_metrics:
-            # no other process in the test VM should take > 30% CPU, by the "settles down" assertion above
-            b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(1) td[data-label='Service']", "cpu-hog")
-            b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(2) td[data-label='Service']", "cpu-piglet")
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) > 50)
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) < 70)
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) > 20)
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) < 40)
-        else:
-            b.wait_not_present("table[aria-label='Top 5 CPU services']")
+        # no other process in the test VM should take > 30% CPU, by the "settles down" assertion above
+        b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(1) td[data-label='Service']", "cpu-hog")
+        b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(2) td[data-label='Service']", "cpu-piglet")
+        b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) > 50)
+        b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) < 70)
+        b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) > 20)
+        b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) < 40)
 
         m.execute("systemctl stop cpu-hog.service cpu-piglet.service")
         # should go back to idle usage
         b.wait(lambda: progressValue("#current-cpu-usage") < 20)
-        if has_cgroups_metrics:
-            b.wait_not_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-hog")
-            b.wait_not_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-piglet")
+        b.wait_not_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-hog")
+        b.wait_not_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-piglet")
 
         # Load looks like "1 min: 1.41, 5 min: 1.47, 15 min: 2.30"
         b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) < 5)
@@ -292,22 +285,19 @@ class TestApplication(testlib.MachineCase):
         hog_usage = progressValue("#current-memory-usage")
         self.assertGreater(hog_usage, initial_usage + 8)
 
-        if has_cgroups_metrics:
-            b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
-            b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) > 300)
-            b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) < 350)
+        b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
+        b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) > 300)
+        b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) < 350)
 
-            # table entries are links to Services page
-            b.click("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service'] a")
-            b.enter_page("/system/services")
-            b.wait_in_text("#path", "/mem-hog.service")
-            b.wait_in_text(".service-name", "MEMBLOB=")
+        # table entries are links to Services page
+        b.click("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service'] a")
+        b.enter_page("/system/services")
+        b.wait_in_text("#path", "/mem-hog.service")
+        b.wait_in_text(".service-name", "MEMBLOB=")
 
-            b.go("/performance-graphs")
-            b.enter_page("/performance-graphs")
-            b.wait_present("table[aria-label='Top 5 memory services']")
-        else:
-            b.wait_not_present("table[aria-label='Top 5 memory services']")
+        b.go("/performance-graphs")
+        b.enter_page("/performance-graphs")
+        b.wait_present("table[aria-label='Top 5 memory services']")
 
         # use even more memory to trigger swap
         m.execute("systemd-run --unit mem-hog2.service sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity'")
@@ -318,8 +308,7 @@ class TestApplication(testlib.MachineCase):
         # should go back to initial_usage; often below, due to paged out stuff
         b.wait(lambda: progressValue("#current-memory-usage") <= initial_usage)
         self.assertGreater(progressValue("#current-memory-usage"), 10)
-        if has_cgroups_metrics:
-            b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
+        b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
 
         # Disk I/O
 


### PR DESCRIPTION
Fedora 32/33 now have cockpit 227, thus cgroup metrics now work
everywhere.