### PR TITLE
Align the two "top 5" tables

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -385,63 +385,71 @@ class CurrentMetrics extends React.Component {
                 <Card>
                     <CardTitle>{ _("CPU") }</CardTitle>
                     <CardBody>
-                        <div className="progress-stack">
-                            <Progress
-                                id="current-cpu-usage"
-                                value={this.state.cpuUsed}
-                                className="pf-m-sm"
-                                min={0} max={100}
-                                variant={ this.state.cpuUsed > 90 ? ProgressVariant.danger : ProgressVariant.info }
-                                title={ num_cpu_str }
-                                label={ this.state.cpuUsed + '% ' } />
+                        <div className="flex-card-contents">
+                            <div className="progress-stack">
+                                <Progress
+                                    id="current-cpu-usage"
+                                    value={this.state.cpuUsed}
+                                    className="pf-m-sm"
+                                    min={0} max={100}
+                                    variant={ this.state.cpuUsed > 90 ? ProgressVariant.danger : ProgressVariant.info }
+                                    title={ num_cpu_str }
+                                    label={ this.state.cpuUsed + '% ' } />
+                            </div>
+
+                            { this.state.loadAvg &&
+                                <DescriptionList isHorizontal>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>{ _("Load") }</DescriptionListTerm>
+                                        <DescriptionListDescription id="load-avg">{this.state.loadAvg}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                </DescriptionList> }
+
+                            <div className="vertical-stretch" />
+
+                            { this.state.topServicesCPU.length > 0 &&
+                                <Table
+                                    variant={TableVariant.compact}
+                                    borders={false}
+                                    aria-label={ _("Top 5 CPU services") }
+                                    cells={ [{ title: _("Service"), transforms: [cellWidth(80)] }, "%"] }
+                                    rows={this.state.topServicesCPU}>
+                                    <TableHeader />
+                                    <TableBody />
+                                </Table> }
                         </div>
-
-                        { this.state.loadAvg &&
-                            <DescriptionList isHorizontal>
-                                <DescriptionListGroup>
-                                    <DescriptionListTerm>{ _("Load") }</DescriptionListTerm>
-                                    <DescriptionListDescription id="load-avg">{this.state.loadAvg}</DescriptionListDescription>
-                                </DescriptionListGroup>
-                            </DescriptionList> }
-
-                        { this.state.topServicesCPU.length > 0 &&
-                            <Table
-                                variant={TableVariant.compact}
-                                borders={false}
-                                aria-label={ _("Top 5 CPU services") }
-                                cells={ [{ title: _("Service"), transforms: [cellWidth(80)] }, "%"] }
-                                rows={this.state.topServicesCPU}>
-                                <TableHeader />
-                                <TableBody />
-                            </Table> }
                     </CardBody>
                 </Card>
 
                 <Card>
                     <CardTitle>{ _("Memory") }</CardTitle>
                     <CardBody>
-                        <div className="progress-stack">
-                            <Progress
-                                id="current-memory-usage"
-                                title={ _("RAM") }
-                                value={this.state.memUsed}
-                                className="pf-m-sm"
-                                min={0} max={memTotal}
-                                variant={memUsedFraction > 0.9 ? ProgressVariant.danger : ProgressVariant.info}
-                                label={ cockpit.format(_("$0 GiB available / $1 GiB total"), memAvail, memTotal) } />
-                            {swapProgress}
-                        </div>
+                        <div className="flex-card-contents">
+                            <div className="progress-stack">
+                                <Progress
+                                    id="current-memory-usage"
+                                    title={ _("RAM") }
+                                    value={this.state.memUsed}
+                                    className="pf-m-sm"
+                                    min={0} max={memTotal}
+                                    variant={memUsedFraction > 0.9 ? ProgressVariant.danger : ProgressVariant.info}
+                                    label={ cockpit.format(_("$0 GiB available / $1 GiB total"), memAvail, memTotal) } />
+                                {swapProgress}
+                            </div>
 
-                        { this.state.topServicesMemory.length > 0 &&
-                            <Table
-                                variant={TableVariant.compact}
-                                borders={false}
-                                aria-label={ _("Top 5 memory services") }
-                                cells={ [{ title: _("Service"), transforms: [cellWidth(80)] }, _("Used")] }
-                                rows={this.state.topServicesMemory}>
-                                <TableHeader />
-                                <TableBody />
-                            </Table> }
+                            <div className="vertical-stretch" />
+
+                            { this.state.topServicesMemory.length > 0 &&
+                                <Table
+                                    variant={TableVariant.compact}
+                                    borders={false}
+                                    aria-label={ _("Top 5 memory services") }
+                                    cells={ [{ title: _("Service"), transforms: [cellWidth(80)] }, _("Used")] }
+                                    rows={this.state.topServicesMemory}>
+                                    <TableHeader />
+                                    <TableBody />
+                                </Table> }
+                        </div>
                     </CardBody>
                 </Card>
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -36,6 +36,16 @@
       --pf-c-description-list--m-horizontal__description--width: minmax(0, auto);
       --pf-c-description-list__group--ColumnGap: 0;
   }
+
+  .flex-card-contents {
+      display: flex;
+      flex-flow: column;
+      height: 100%;
+
+      .vertical-stretch {
+          flex-grow: 1;
+      }
+  }
 }
 
 .metrics {


### PR DESCRIPTION
Use an extra blank "vertical stretch" filler element that pushes the
table at the bottom of the card, so that they stay aligned with each
other.

Now they look right:

![image](https://user-images.githubusercontent.com/200109/92621278-ef90a500-f2c3-11ea-95b5-8ed09745a688.png)

Also with swap:

![image](https://user-images.githubusercontent.com/200109/92626487-439e8800-f2ca-11ea-8523-e2a9ecc6ead2.png)

Previously:

![image](https://user-images.githubusercontent.com/200109/92616519-9c682380-f2be-11ea-91fb-e987c64a339f.png)

 - [x] Builds on top of #36
