### PR TITLE
Move to DescriptionList

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "webpack-cli": "^3.3.5"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.23.3",
-    "@patternfly/react-core": "4.32.1",
-    "@patternfly/react-table": "4.15.5",
+    "@patternfly/patternfly": "4.35.2",
+    "@patternfly/react-core": "4.47.0",
+    "@patternfly/react-table": "4.16.7",
     "core-js": "3.6.5",
     "moment": "2.27.0",
     "react": "16.13.1",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -25,6 +25,7 @@ import {
     Alert,
     Button,
     Card, CardTitle, CardBody, Gallery,
+    DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
     Page, PageSection,
     Progress, ProgressVariant,
 } from '@patternfly/react-core';
@@ -396,14 +397,12 @@ class CurrentMetrics extends React.Component {
                         </div>
 
                         { this.state.loadAvg &&
-                            <table className="info-table">
-                                <tbody>
-                                    <tr>
-                                        <th>{ _("Load:") }</th>
-                                        <td id="load-avg">{this.state.loadAvg}</td>
-                                    </tr>
-                                </tbody>
-                            </table> }
+                            <DescriptionList isHorizontal>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>{ _("Load:") }</DescriptionListTerm>
+                                    <DescriptionListDescription id="load-avg">{this.state.loadAvg}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                            </DescriptionList> }
 
                         { this.state.topServicesCPU.length > 0 &&
                             <Table
@@ -449,16 +448,16 @@ class CurrentMetrics extends React.Component {
                 <Card>
                     <CardTitle>{ _("Disks") }</CardTitle>
                     <CardBody>
-                        <table className="info-table">
-                            <tbody>
-                                <tr>
-                                    <th>{ _("Reading:") }</th>
-                                    <td id="current-disks-read">{ cockpit.format_bytes_per_sec(this.state.disksRead) }</td>
-                                    <th>{ _("Writing:") }</th>
-                                    <td id="current-disks-write">{ cockpit.format_bytes_per_sec(this.state.disksWritten) }</td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <DescriptionList isHorizontal columnModifier={{ lg: '2Col' }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{ _("Reading:") }</DescriptionListTerm>
+                                <DescriptionListDescription id="current-disks-read">{ cockpit.format_bytes_per_sec(this.state.disksRead) }</DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{ _("Writing:") }</DescriptionListTerm>
+                                <DescriptionListDescription id="current-disks-write">{ cockpit.format_bytes_per_sec(this.state.disksWritten) }</DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
 
                         <div className="progress-stack"> {
                             this.state.mounts.map(info => <Progress

--- a/src/app.scss
+++ b/src/app.scss
@@ -30,13 +30,11 @@
       grid-gap: 0;
   }
 
-  .info-table {
-       th {
-           padding-right: 0.5em;
-       }
-       td {
-           padding-right: 1em;
-       }
+  // default is way too wide for the cards
+  .pf-c-description-list {
+      --pf-c-description-list--m-horizontal__term--width: minmax(0, auto);
+      --pf-c-description-list--m-horizontal__description--width: minmax(0, auto);
+      --pf-c-description-list__group--ColumnGap: 0;
   }
 }
 


### PR DESCRIPTION
The default layout uses way too much horizontal gaps, which causes the 
list to overflow to the right. Disable the extra spacing.

Fixes #16 

Before:
![image](https://user-images.githubusercontent.com/200109/92690015-6c616480-f340-11ea-8143-e6eb9fc09726.png)

Now:
![image](https://user-images.githubusercontent.com/200109/92689957-55227700-f340-11ea-8ec7-cf30bc360273.png)

Mobile:
![image](https://user-images.githubusercontent.com/200109/92690102-9a46a900-f340-11ea-8e5b-99710484475e.png)

 - [x] Builds on top of PR #36