### PR TITLE
Divide cpu load by number of cores

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -344,7 +344,7 @@ class CurrentMetrics extends React.Component {
 
         // top 5 CPU and memory consuming systemd units
         newState.topServicesCPU = n_biggest(this.cgroupCPUNames, this.samples[9], 5).map(
-            x => serviceRow(x[0], Number(x[1] / 10).toFixed(1)) // usec/s → percent
+            x => serviceRow(x[0], Number(x[1] / 10 / numCpu).toFixed(1)) // usec/s → percent
         );
 
         newState.topServicesMemory = n_biggest(this.cgroupMemoryNames, this.samples[10], 5).map(


### PR DESCRIPTION
before: (the top 5 processes are nowhere near the full usage)
![normalized](https://user-images.githubusercontent.com/12330670/93469259-8a0a6d00-f8f0-11ea-8d3d-fcaa5f8f1ff9.png)

now: (top 5 processes almost add up to the full usage)
![newone](https://user-images.githubusercontent.com/12330670/93469338-a6a6a500-f8f0-11ea-8b47-77b3064dab64.png)
