### PR TITLE
Put history graphs into a card

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -808,16 +808,22 @@ class MetricsHistory extends React.Component {
         return (
             <div className="metrics">
                 { this.state.hours.length > 0 &&
-                    <Card>
-                        <CardBody className="metrics-history">
-                            <div className="metrics-label">{ _("Events") }</div>
-                            <div className="metrics-label metrics-label-graph">{ _("CPU") }</div>
-                            <div className="metrics-label metrics-label-graph">{ _("Memory") }</div>
-                            <div className="metrics-label metrics-label-graph">{ _("Disks") }</div>
-                            <div className="metrics-label metrics-label-graph">{ _("Network") }</div>
-                            { this.state.hours.map(time => <MetricsHour key={time} startTime={parseInt(time)} data={this.data[time]} />) }
-                        </CardBody>
-                    </Card>}
+                    <>
+                        <div className="metrics-history-heading-sticky">
+                            <section className="metrics-history metrics-history-heading">
+                                <div className="metrics-label">{ _("Events") }</div>
+                                <div className="metrics-label metrics-label-graph">{ _("CPU") }</div>
+                                <div className="metrics-label metrics-label-graph">{ _("Memory") }</div>
+                                <div className="metrics-label metrics-label-graph">{ _("Disks") }</div>
+                                <div className="metrics-label metrics-label-graph">{ _("Network") }</div>
+                            </section>
+                        </div>
+                        <Card>
+                            <CardBody className="metrics-history">
+                                { this.state.hours.map(time => <MetricsHour key={time} startTime={parseInt(time)} data={this.data[time]} />) }
+                            </CardBody>
+                        </Card>
+                    </>}
                 {nodata_alert}
                 <div className="bottom-panel">
                     { this.state.loading

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -808,15 +808,16 @@ class MetricsHistory extends React.Component {
         return (
             <div className="metrics">
                 { this.state.hours.length > 0 &&
-                    <section className="metrics-history">
-                        <div className="metrics-label">{ _("Events") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("CPU") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("Memory") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("Disks") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("Network") }</div>
-
-                        { this.state.hours.map(time => <MetricsHour key={time} startTime={parseInt(time)} data={this.data[time]} />) }
-                    </section> }
+                    <Card>
+                        <CardBody className="metrics-history">
+                            <div className="metrics-label">{ _("Events") }</div>
+                            <div className="metrics-label metrics-label-graph">{ _("CPU") }</div>
+                            <div className="metrics-label metrics-label-graph">{ _("Memory") }</div>
+                            <div className="metrics-label metrics-label-graph">{ _("Disks") }</div>
+                            <div className="metrics-label metrics-label-graph">{ _("Network") }</div>
+                            { this.state.hours.map(time => <MetricsHour key={time} startTime={parseInt(time)} data={this.data[time]} />) }
+                        </CardBody>
+                    </Card>}
                 {nodata_alert}
                 <div className="bottom-panel">
                     { this.state.loading

--- a/src/app.scss
+++ b/src/app.scss
@@ -101,20 +101,8 @@
         position: inherit;
     }
 
-    &-info,
-    &-events {
-        padding: 0 1rem;
-    }
-
-    &-label {
-        background: #ddd;
-        position: sticky;
-        top: 0;
-        z-index: 99;
-
-        &-graph {
-            text-align: center;
-        }
+    &-label-graph {
+        text-align: center;
     }
 
     &-time {
@@ -208,6 +196,30 @@
         bottom: 0;
         left: 50%;
         border-left: 1px dotted rgba(0,0,0,0.3);
+    }
+
+    .pf-c-card__body:first-child {
+        padding-top: 0;
+    }
+
+    &-history-heading {
+        background: #fff;
+
+        padding-right: calc(var(--pf-global--spacer--lg) + var(--pf-c-page__main-section--PaddingRight));
+        padding-left: calc(var(--pf-global--spacer--lg) + var(--pf-c-page__main-section--PaddingLeft));
+        margin-bottom: 1rem;
+
+        position: relative;
+        width: calc(100% + var(--pf-c-page__main-section--PaddingRight) + var(--pf-c-page__main-section--PaddingLeft));
+        right: var(--pf-c-page__main-section--PaddingRight);
+
+        box-shadow: var(--pf-global--BoxShadow--sm);
+
+        &-sticky {
+            position: sticky;
+            top: 0;
+            z-index: 99;
+        }
     }
 }
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -96,6 +96,9 @@
     &-time,
     &-label {
         padding: 0.5rem 1rem;
+        width: calc(100% + var(--pf-c-card--child--PaddingRight) + var(--pf-c-card--child--PaddingBottom));
+        right: var(--pf-c-card--child--PaddingRight);
+        position: inherit;
     }
 
     &-info,

--- a/test/check-application
+++ b/test/check-application
@@ -49,8 +49,8 @@ class TestApplication(testlib.MachineCase):
 
         self.login_and_go("/performance-graphs")
         # eventually finishes data loading and shows heading
-        b.wait_in_text(".metrics-history", "Events")
-        b.wait_in_text(".metrics-history", "CPU")
+        b.wait_in_text(".metrics-history-heading", "Events")
+        b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
 
         # only shows current hour
@@ -100,8 +100,8 @@ class TestApplication(testlib.MachineCase):
 
         self.login_and_go("/performance-graphs")
         # eventually finishes data loading and shows heading
-        b.wait_in_text(".metrics-history", "Events")
-        b.wait_in_text(".metrics-history", "CPU")
+        b.wait_in_text(".metrics-history-heading", "Events")
+        b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
 
         # Big spike lasting 3 minutes
@@ -132,8 +132,8 @@ class TestApplication(testlib.MachineCase):
 
         self.login_and_go("/performance-graphs")
         # eventually finishes data loading and shows heading
-        b.wait_in_text(".metrics-history", "Events")
-        b.wait_in_text(".metrics-history", "CPU")
+        b.wait_in_text(".metrics-history-heading", "Events")
+        b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
 
         # Test network - Big spike lasting 2 minutes
@@ -188,8 +188,8 @@ class TestApplication(testlib.MachineCase):
 
         prepareArchive(m, "memory.tar.gz", 1600248000)
         self.login_and_go("/performance-graphs")
-        b.wait_in_text(".metrics-history", "Events")
-        b.wait_in_text(".metrics-history", "CPU")
+        b.wait_in_text(".metrics-history-heading", "Events")
+        b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
 
         # basic RAM consumption after boot


### PR DESCRIPTION
Now I will replace 'Events' with time select. Wanted to send this separately so we can tweak the design while I work on the time-changing functionality. Design from https://github.com/martinpitt/performance-graphs/issues/35
@garrett and @martinpitt WDYT?

Before:
![beforepg](https://user-images.githubusercontent.com/12330670/93872061-e3e3ac00-fccf-11ea-91a9-2c4d666f8bfd.png)

Now:
![newheader](https://user-images.githubusercontent.com/12330670/93874091-22c73100-fcd3-11ea-8689-125c869f2b2a.png)

And it is sticky, so after scrolling:
![issticky](https://user-images.githubusercontent.com/12330670/93874114-2bb80280-fcd3-11ea-9a1d-28acd1cb1f20.png)
