### PR TITLE
build: Don't complain about handler names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,8 @@
         "eqeqeq": "off",
         "import/no-webpack-loader-syntax": "off",
         "object-property-newline": "off",
-        "react/jsx-no-bind": "off"
+        "react/jsx-no-bind": "off",
+        "react/jsx-handler-names": "off"
     },
     "globals": {
         "require": false,


### PR DESCRIPTION
Otherwise, eslint doesn't allow code like

    onClick={ev => ...}