### PR TITLE
Hide ruler tick marks for nonexisting graphs

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -533,7 +533,7 @@ const SvgGraph = ({ data, resource, have_sat }) => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox={ "0 0 2 " + SVG_YMAX } preserveAspectRatio="none">
             <polygon
-                 transform={ "matrix(-1,0,0,-1,1," + SVG_YMAX + ")" }
+                 transform={ have_sat ? "matrix(-1,0,0,-1,1," + SVG_YMAX + ")" : "matrix(-2,0,0,-1,2," + SVG_YMAX + ")" }
                  points={ dataPoints("use_" + resource) }
             />
             { have_sat && <polygon
@@ -922,8 +922,8 @@ class MetricsHistory extends React.Component {
                         >
                             {options}
                         </Select>
-                        <div className="metrics-label metrics-label-graph">{ _("CPU") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("Memory") }</div>
+                        <div className="metrics-label metrics-label-graph have-saturation">{ _("CPU") }</div>
+                        <div className="metrics-label metrics-label-graph have-saturation">{ _("Memory") }</div>
                         <div className="metrics-label metrics-label-graph">{ _("Disks") }</div>
                         <div className="metrics-label metrics-label-graph">{ _("Network") }</div>
                     </section>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -616,7 +616,7 @@ const MetricsHour = ({ startTime, data }) => {
             graphs.push(
                 <div
                     key={ resource + startTime + minute }
-                    className={ ("metrics-data metrics-data-" + resource) + (first ? " valid-data" : " empty-data")}
+                    className={ ("metrics-data metrics-data-" + resource) + (first ? " valid-data" : " empty-data") + (have_sat ? " have-saturation" : "") }
                     style={{ "--metrics-minute": minute }}
                     aria-hidden="true"
                 >

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -907,6 +907,17 @@ class MetricsHistory extends React.Component {
             );
         }
 
+        function Label(props) {
+            return (
+                <div className={"metrics-label metrics-label-graph" + (props.items.length > 1 ? " have-saturation" : "")}>
+                    <span>{props.label}</span>
+                    <span className="metrics-sublabels">
+                        { props.items.map(i => <span key={i}>{i}</span>) }
+                    </span>
+                </div>
+            );
+        }
+
         return (
             <div className="metrics">
                 <div className="metrics-history-heading-sticky">
@@ -922,10 +933,10 @@ class MetricsHistory extends React.Component {
                         >
                             {options}
                         </Select>
-                        <div className="metrics-label metrics-label-graph have-saturation">{ _("CPU") }</div>
-                        <div className="metrics-label metrics-label-graph have-saturation">{ _("Memory") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("Disks") }</div>
-                        <div className="metrics-label metrics-label-graph">{ _("Network") }</div>
+                        <Label label={_("CPU")} items={[_("Usage"), _("Load")]} />
+                        <Label label={_("Memory")} items={[_("Usage"), _("Swap")]} />
+                        <Label label={_("Disks")} items={[_("Usage")]} />
+                        <Label label={_("Network")} items={[_("Usage")]} />
                     </section>
                 </div>
                 { this.state.hours.length > 0 &&

--- a/src/app.scss
+++ b/src/app.scss
@@ -293,18 +293,27 @@
         margin-left: 0.5rem;
         margin-right: 0.5rem;
 
-        &.valid-data {
-            border-top: 1px solid rgba(0,0,0,0.3);
-        }
-        // vertical ruler line for areas with data
-        &.valid-data:after {
+        // vertical ruler line for areas with data, and horizontal tick mark for utilization half
+        &.valid-data:before {
             content: "";
             position: absolute;
             z-index: 1;
             top: 0;
             bottom: 0;
-            left: 50%;
-            border-left: 1px solid rgba(0,0,0,0.3);
+            width: 50%;
+            border-right: 1px solid rgba(0,0,0,0.3);
+            border-top: 1px solid rgba(0,0,0,0.3);
+        }
+
+        // horizontal tick mark for saturation half, for resources that have it
+        &.valid-data.have-saturation:after {
+            content: "";
+            position: absolute;
+            z-index: 1;
+            top: 0;
+            bottom: 0;
+            width: 50%;
+            border-top: 1px solid rgba(0,0,0,0.3);
         }
 
         > svg {

--- a/src/app.scss
+++ b/src/app.scss
@@ -252,14 +252,31 @@
         width: calc(100% + var(--pf-c-card--child--PaddingRight) + var(--pf-c-card--child--PaddingBottom));
         right: var(--pf-c-card--child--PaddingRight);
         position: inherit;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+    }
+
+    &-sublabels {
+        font-size: 65%;
+        color: rgba(0,0,0,0.7);
+        display: flex;
     }
 
     &-label-graph {
         text-align: right;
+
+        & .metrics-sublabels {
+            justify-content: flex-end;
+        }
     }
 
     &-label-graph.have-saturation {
         text-align: center;
+
+        & .metrics-sublabels {
+            justify-content: space-evenly;
+        }
     }
 
     &-time {

--- a/src/app.scss
+++ b/src/app.scss
@@ -229,13 +229,14 @@
 
 .metrics {
     --column-size: minmax(5rem, 10vw);
+    --half-column-size: minmax(2.5rem, 5vw);
     --data-min-height:5px;
     --data-gap: 0;
     &-history,
     &-hour {
         display: grid;
         grid-template: "events cpu memory disks net";
-        grid-template-columns: [events] 3fr [cpu] var(--column-size) [memory] var(--column-size) [disks] var(--column-size) [network] var(--column-size);
+        grid-template-columns: [events] 3fr [cpu] var(--column-size) [memory] var(--column-size) [disks] var(--half-column-size) [network] var(--half-column-size);
         grid-column: 1 / -1;
         position: relative;
     }
@@ -254,6 +255,10 @@
     }
 
     &-label-graph {
+        text-align: right;
+    }
+
+    &-label-graph.have-saturation {
         text-align: center;
     }
 
@@ -300,10 +305,15 @@
             z-index: 1;
             top: 0;
             bottom: 0;
-            width: 50%;
+            width: 100%;
             border-right: 1px solid rgba(0,0,0,0.3);
             border-top: 1px solid rgba(0,0,0,0.3);
         }
+
+        &.valid-data.have-saturation:before {
+            width: 50%;
+        }
+
 
         // horizontal tick mark for saturation half, for resources that have it
         &.valid-data.have-saturation:after {
@@ -313,6 +323,7 @@
             top: 0;
             bottom: 0;
             width: 50%;
+            left: 50%;
             border-top: 1px solid rgba(0,0,0,0.3);
         }
 
@@ -350,10 +361,10 @@
         /* compressed minutes without events are simple bars */
         .compressed {
             display: grid;
-            grid-template-areas: ". utilization saturation .";
-            --util-pct: calc(50% * var(--utilization));
-            --sat-pct: calc(50% * var(--saturation));
-            grid-template-columns: calc(50% - var(--util-pct)) var(--util-pct) var(--sat-pct) calc(50% - var(--sat-pct));
+            grid-template-areas: ". utilization .";
+
+            --util-pct: calc(100% * var(--utilization));
+            grid-template-columns: calc(100% - var(--util-pct)) var(--util-pct);
 
             > .saturation,
             > .utilization {
@@ -369,17 +380,34 @@
                 opacity: 0.7;
             }
         }
+
+        &.have-saturation .compressed {
+            grid-template-areas: ". utilization saturation .";
+            --util-pct: calc(50% * var(--utilization));
+            --sat-pct: calc(50% * var(--saturation));
+            grid-template-columns: calc(50% - var(--util-pct)) var(--util-pct) var(--sat-pct) calc(50% - var(--sat-pct));
+        }
     }
 
     // vertical dotted line through graph center, for areas without data
     &-data:after {
         content: "";
-        position: absolute;
         z-index: -1;
         top: 0;
         bottom: 0;
-        left: 50%;
+        position: absolute;
+    }
+
+    &-data.empty-data:after {
+        position: initial;
+        border-right: 1px dotted rgba(0,0,0,0.3);
+    }
+
+    &-data.empty-data.have-saturation:after {
+        position: absolute;
         border-left: 1px dotted rgba(0,0,0,0.3);
+        border-right: none;
+        left: 50%;
     }
 
     .pf-c-card__body:first-child {


### PR DESCRIPTION
Disk/net saturation graphs are not a thing, so don't render the ruler
tick marks for these.

For that, split the `border-top` property into two halfes, and 
conditionalize the right half on a new `.have-saturation` class.

Fixes #60 

 - [x] Builds on top of PR #62