### PR TITLE
Redesign Disks/Memory metrics to conserve space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ $(RPMFILE): $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 # build a VM with locally built rpm installed
 $(VM_IMAGE): $(RPMFILE) bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
-	bots/image-customize -v -i cockpit-ws -i `pwd`/$(RPMFILE) -s $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize -v -i cockpit-ws -i cockpit-storaged -i `pwd`/$(RPMFILE) -s $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -373,14 +373,18 @@ class CurrentMetrics extends React.Component {
         if (swapTotal) {
             const swapUsedFraction = this.state.swapUsed / swapTotal;
             const swapAvail = Number(swapTotal - this.state.swapUsed).toFixed(1);
-            swapProgress = <Progress
-                                id="current-swap-usage"
-                                title={ _("Swap") }
-                                value={this.state.swapUsed}
-                                className="pf-m-sm"
-                                min={0} max={swapTotal}
-                                variant={swapUsedFraction > 0.9 ? ProgressVariant.danger : ProgressVariant.info}
-                                label={ cockpit.format(_("$0 GiB available / $1 GiB total"), swapAvail, swapTotal) } />;
+            swapProgress = (
+                <Tooltip content={ cockpit.format(_("$0 GiB total"), swapTotal) } position="bottom">
+                    <Progress
+                        id="current-swap-usage"
+                        tabIndex="0"
+                        title={ _("Swap") }
+                        value={this.state.swapUsed}
+                        className="pf-m-sm"
+                        min={0} max={swapTotal}
+                        variant={swapUsedFraction > 0.9 ? ProgressVariant.danger : ProgressVariant.info}
+                        label={ cockpit.format(_("$0 GiB available"), swapAvail) } />
+                </Tooltip>);
         }
 
         return (
@@ -424,14 +428,19 @@ class CurrentMetrics extends React.Component {
                     <CardTitle>{ _("Memory") }</CardTitle>
                     <CardBody>
                         <div className="progress-stack">
-                            <Progress
-                                id="current-memory-usage"
-                                title={ _("RAM") }
-                                value={this.state.memUsed}
-                                className="pf-m-sm"
-                                min={0} max={memTotal}
-                                variant={memUsedFraction > 0.9 ? ProgressVariant.danger : ProgressVariant.info}
-                                label={ cockpit.format(_("$0 GiB available / $1 GiB total"), memAvail, memTotal) } />
+                            <Tooltip
+                                content={ cockpit.format(_("$0 GiB total"), memTotal) }
+                                position="bottom">
+                                <Progress
+                                    id="current-memory-usage"
+                                    tabIndex="0"
+                                    title={ _("RAM") }
+                                    value={this.state.memUsed}
+                                    className="pf-m-sm"
+                                    min={0} max={memTotal}
+                                    variant={memUsedFraction > 0.9 ? ProgressVariant.danger : ProgressVariant.info}
+                                    label={ cockpit.format(_("$0 GiB available"), memAvail) } />
+                            </Tooltip>
                             {swapProgress}
                         </div>
 

--- a/test/check-application
+++ b/test/check-application
@@ -355,6 +355,11 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) > 300)
         b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) < 350)
 
+        # total memory is shown as tooltip
+        b.mouse("#current-memory-usage", "mouseenter")
+        b.wait_in_text(".pf-c-tooltip", "GiB total")
+        b.mouse("#current-memory-usage", "mouseleave")
+
         # table entries are links to Services page
         b.click("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service'] a span")
         b.enter_page("/system/services")
@@ -375,6 +380,11 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: progressValue("#current-memory-usage") <= initial_usage)
         self.assertGreater(progressValue("#current-memory-usage"), 10)
         b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
+
+        # total swap is shown as tooltip
+        b.mouse("#current-swap-usage", "mouseenter")
+        b.wait_in_text(".pf-c-tooltip", "GiB total")
+        b.mouse("#current-swap-usage", "mouseleave")
 
         # Disk I/O
 

--- a/test/check-application
+++ b/test/check-application
@@ -409,12 +409,39 @@ class TestApplication(testlib.MachineCase):
                   """)
         self.addCleanup(self.machine.execute, "umount /var/cockpittest")
         self.assertLess(progressValue(".pf-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)
-        free = b.text(".pf-c-progress[data-disk-usage-target='/var/cockpittest'] .pf-c-progress__status")
-        # anything between 40 and 50 MB
-        self.assertRegex(free, "^4\d\.\d MB free / 4\d\.\d MB total$")
+        progress_sel = ".pf-c-progress[data-disk-usage-target='/var/cockpittest'] .pf-c-progress__status"
+        # free size is anything between 40 and 50 MB
+        self.assertRegex(b.text(progress_sel), "^4\d\.\d MB free$")
+        # total size is shown in tooltip
+        b.mouse(progress_sel, "mouseenter")
+        b.wait_in_text(".pf-c-tooltip", "total")
+        # total size is anything between 40 and 50 MB
+        self.assertRegex(b.text(".pf-c-tooltip"), "^4\d\.\d MB total$")
+        b.mouse(progress_sel, "mouseleave")
 
         m.execute("dd if=/dev/zero of=/var/cockpittest/blob bs=1M count=40")
         b.wait(lambda: progressValue(".pf-c-progress[data-disk-usage-target='/var/cockpittest']") >= 90)
+
+        # clicking on progress leads to the storage page
+        self.assertTrue(b.is_present("#current-disks-usage button"))
+        b.click(progress_sel)
+        b.enter_page("/storage")
+        # weird -- storage page does not show transient mount points, only permanent ones; so check for the device
+        dev = m.execute("findmnt --noheadings -o SOURCE /var/cockpittest").strip()
+        b.wait_in_text("#mounts", dev)
+
+        b.go("/performance-graphs")
+        b.enter_page("/performance-graphs")
+        b.wait_present(progress_sel)
+        b.logout()
+
+        # without cockpit-storaged, mounts are not links
+        self.restore_file("/usr/share/cockpit/storaged/manifest.json")
+        m.write("/usr/share/cockpit/storaged/manifest.json", "")
+        self.allow_journal_messages("storaged: couldn't read manifest.json: JSON data was empty")
+        b.login_and_go("/performance-graphs")
+        b.wait_present(progress_sel)
+        self.assertFalse(b.is_present("#current-disks-usage button"))
 
         # Network usage
 


### PR DESCRIPTION
Move the total size into a tooltip to conserve space.

If cockpit-storaged is available, turn the mount point usage info into
links to the Storage page. There is no specific subpage for each mount,
the main page has a "Filesystems" table with all of them.

Wrap the entire <Progress> as link, so that the tooltip works properly
both with mouse hovering and with keyboard focusing, and the tooltip
points to the progress bar instead of just the text label.

Fixes #43