### PR TITLE
Avoid near-zero disk/network rates

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -364,8 +364,8 @@ class CurrentMetrics extends React.Component {
 
         const netIO = this.netInterfacesNames.map((iface, i) => [
             iface,
-            cockpit.format_bytes_per_sec(this.state.netInterfacesRx[i]),
-            cockpit.format_bytes_per_sec(this.state.netInterfacesTx[i]),
+            this.state.netInterfacesRx[i] >= 1 ? cockpit.format_bytes_per_sec(this.state.netInterfacesRx[i]) : "0",
+            this.state.netInterfacesTx[i] >= 1 ? cockpit.format_bytes_per_sec(this.state.netInterfacesTx[i]) : "0",
         ]);
 
         let swapProgress;
@@ -463,11 +463,11 @@ class CurrentMetrics extends React.Component {
                         <DescriptionList isHorizontal columnModifier={{ lg: '2Col' }}>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{ _("Read") }</DescriptionListTerm>
-                                <DescriptionListDescription id="current-disks-read">{ cockpit.format_bytes_per_sec(this.state.disksRead) }</DescriptionListDescription>
+                                <DescriptionListDescription id="current-disks-read">{ this.state.disksRead >= 1 ? cockpit.format_bytes_per_sec(this.state.disksRead) : "0" }</DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{ _("Write") }</DescriptionListTerm>
-                                <DescriptionListDescription id="current-disks-write">{ cockpit.format_bytes_per_sec(this.state.disksWritten) }</DescriptionListDescription>
+                                <DescriptionListDescription id="current-disks-write">{ this.state.disksWritten >= 1 ? cockpit.format_bytes_per_sec(this.state.disksWritten) : "0" }</DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>
 

--- a/test/check-application
+++ b/test/check-application
@@ -394,8 +394,8 @@ class TestApplication(testlib.MachineCase):
         # Disk I/O
 
         # test env should be quiet enough to not transmit MB/s
-        b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-read")))
-        b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-write")))
+        b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-read")))
+        b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-write")))
         # reading lots of data
         m.execute("systemd-run --slice cockpittest --unit disk-read-hog sh -ec 'grep -r . /usr >/dev/null'")
         b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-read")))
@@ -409,7 +409,7 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-write")))
         b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-read")))  # this should stay calm
         m.execute("systemctl stop disk-write-hog")
-        b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-write")))
+        b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-write")))
 
         # Disk usage
 
@@ -469,14 +469,20 @@ class TestApplication(testlib.MachineCase):
             return re.match(regexp, text) is not None
 
         # loopback is quiet enough to not transmit MB/s
-        b.wait(lambda: rateMatches("In", r'^[0-9.]+ (KiB|B)/s$'))
-        b.wait(lambda: rateMatches("Out", r'^[0-9.]+ (KiB|B)/s$'))
+        b.wait(lambda: rateMatches("In", r'^(0|[0-9.]+ (KiB|B)/s)$'))
+        b.wait(lambda: rateMatches("Out", r'^(0|$[0-9.]+ (KiB|B)/s)$'))
         # pipe lots of data through lo
         m.execute("systemd-run --slice cockpittest --unit lo-hog sh -ec "
                   " 'nc -l 2000 > /dev/null & nc localhost 2000 </dev/zero'")
         b.wait(lambda: rateMatches("In", r'^[0-9.]+ (MiB|GiB)/s$'))
         b.wait(lambda: rateMatches("Out", r'^[0-9.]+ (MiB|GiB)/s$'))
         m.execute("systemctl stop lo-hog")
+
+        # add synthetic veth which is guaranteed quiet
+        m.execute("ip link add name cockpittest1 type veth peer name vcockpittest1")
+        self.addCleanup(m.execute, "ip link del dev cockpittest1")
+        b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='In']", "0")
+        b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='Out']", "0")
 
 
 class TestMultiCPU(testlib.MachineCase):


### PR DESCRIPTION
Avoid near-zero disk/network rates

Only show disk read/write and network interface in/out rates if they
are >= 1 Byte/s, otherwise just show a "0".

Adjust the integration tests to also accept "0" (without unit) as an
"almost quiet" value. Test "exactly quiet" network rates with a veth.
Don't explicitly test "exactly quiet" disk I/O, as that's hard to
guarantee in an integration test.

Fixes #70 