### PR TITLE
Add breadcrumb

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -23,6 +23,7 @@ import moment from "moment";
 import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
 import {
     Alert,
+    Breadcrumb, BreadcrumbItem,
     Button,
     Card, CardTitle, CardBody, Gallery,
     DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
@@ -939,7 +940,12 @@ class MetricsHistory extends React.Component {
 }
 
 export const Application = () => (
-    <Page>
+    <Page breadcrumb={
+        <Breadcrumb>
+            <BreadcrumbItem onClick={() => cockpit.jump("/system")} to="#">{_("Overview")}</BreadcrumbItem>
+            <BreadcrumbItem isActive>{_("Performance Metrics")}</BreadcrumbItem>
+        </Breadcrumb>
+    }>
         <PageSection>
             <CurrentMetrics />
         </PageSection>

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,9 @@
 #app {
     height: 100%;
+
+    section.pf-c-page__main-breadcrumb {
+        padding-bottom: var(--pf-c-page__main-breadcrumb--PaddingTop);
+     }
 }
 
 // FIXME: More styles from ct-system-overview

--- a/test/check-application
+++ b/test/check-application
@@ -96,6 +96,11 @@ class TestApplication(testlib.MachineCase):
         b.click(".pf-c-select__menu-wrapper:nth-child(2) button")
         b.wait_text(".pf-c-empty-state", "No data available")
 
+        # Breadcrumb back to Overview page
+        b.click(".pf-c-breadcrumb li:first-child a")
+        b.enter_page("/system")
+        b.wait_visible('.system-information')
+
     def testEvents(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Once we integrate this into main Cockpit, this will appear to be a
sub-page of Overview (/system). We get to it through the "Usage" card's
"View graphs" link, so provide a way to get back.

![image](https://user-images.githubusercontent.com/200109/94518362-14749a00-022a-11eb-8e6d-ebae92bb4501.png)
