### PR TITLE
Rename page to "metrics"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TEST_OS = fedora-32
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
-RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-performance-graphs.spec.in).rpm
+RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-metrics.spec.in).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
 NODE_MODULES_TEST=package-lock.json

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ tree. To do that, link that to the location were `cockpit-bridge` looks for pack
 
 ```
 mkdir -p ~/.local/share/cockpit
-ln -s `pwd`/dist ~/.local/share/cockpit/performance-graphs
+ln -s `pwd`/dist ~/.local/share/cockpit/metrics
 ```
 
 After changing the code and running `make` again, reload the Cockpit page in

--- a/cockpit-metrics.spec.in
+++ b/cockpit-metrics.spec.in
@@ -1,10 +1,10 @@
-Name: cockpit-performance-graphs
+Name: cockpit-metrics
 Version: %{VERSION}
 Release: 1%{?dist}
 Summary: Cockpit Starter Kit Example Module
 License: LGPLv2+
 
-Source: cockpit-performance-graphs-%{version}.tar.gz
+Source: cockpit-metrics-%{version}.tar.gz
 BuildArch: noarch
 BuildRequires:  libappstream-glib
 
@@ -17,7 +17,7 @@ Recommends: cockpit-pcp
 Cockpit Starter Kit Example Module
 
 %prep
-%setup -n cockpit-performance-graphs
+%setup -n cockpit-metrics
 
 %install
 %make_install

--- a/cockpituous-release
+++ b/cockpituous-release
@@ -8,7 +8,7 @@
 # Check cockpituous documentation for available release targets.
 
 RELEASE_SOURCE="_release/source"
-RELEASE_SPEC="cockpit-performance-graphs.spec"
+RELEASE_SPEC="cockpit-metrics.spec"
 RELEASE_SRPM="_release/srpm"
 
 job release-source

--- a/org.cockpit-project.metrics.metainfo.xml
+++ b/org.cockpit-project.metrics.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit_project.performance-graphs</id>
+  <id>org.cockpit_project.metrics</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Starter Kit</name>
   <summary>
@@ -12,5 +12,5 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">performance-graphs</launchable>
+  <launchable type="cockpit-manifest">metrics</launchable>
 </component>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "performance-graphs",
+  "name": "metrics",
   "version": "0.1.0",
   "description": "Scaffolding for a cockpit module",
   "main": "index.js",

--- a/test/check-application
+++ b/test/check-application
@@ -67,7 +67,7 @@ class TestApplication(testlib.MachineCase):
 
         m.execute("systemctl start pmlogger")
 
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
         # eventually finishes data loading and shows heading
         b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
@@ -115,7 +115,7 @@ class TestApplication(testlib.MachineCase):
 
         prepareArchive(m, "disk.tar.gz", 1597672800)
 
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
         # eventually finishes data loading and shows heading
         b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
@@ -146,7 +146,7 @@ class TestApplication(testlib.MachineCase):
 
         prepareArchive(m, "cpu_network.tar.gz", 1598918400)
 
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
         # eventually finishes data loading and shows heading
         b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
@@ -202,7 +202,7 @@ class TestApplication(testlib.MachineCase):
         #
 
         prepareArchive(m, "memory.tar.gz", 1600248000)
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
         b.wait_in_text(".metrics-history-heading", "CPU")
         b.wait_present(".metrics-hour .metrics-data-cpu")
 
@@ -242,7 +242,7 @@ class TestApplication(testlib.MachineCase):
         #
 
         m.execute("timedatectl set-time @1600550674")
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
         # self.waitStream(3) # FIXME: wait for new data - pcp does not handle time change greatly
         b.wait_text(".pf-c-select__toggle-text", "Today")
 
@@ -263,7 +263,7 @@ class TestApplication(testlib.MachineCase):
         m.execute("systemctl stop pmlogger && mount -t tmpfs tmpfs /var/log/pcp/pmlogger")
         self.addCleanup(m.execute, "umount /var/log/pcp/pmlogger")
 
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
 
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
         # Troubleshoot
@@ -279,7 +279,7 @@ class TestApplication(testlib.MachineCase):
         m.execute("mount -t tmpfs tmpfs /usr/share/cockpit/pcp")
         self.addCleanup(m.execute, "umount /usr/share/cockpit/pcp")
 
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
         b.wait_in_text(".pf-c-empty-state", "cockpit-pcp is missing")
         b.click(".pf-c-empty-state button.pf-m-primary")
         # this button does not yet do anything
@@ -289,7 +289,7 @@ class TestApplication(testlib.MachineCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
 
         def progressValue(progress_bar_sel):
             sel = progress_bar_sel + " .pf-c-progress__indicator"
@@ -371,8 +371,8 @@ class TestApplication(testlib.MachineCase):
         b.wait_in_text("#path", "/mem-hog.service")
         b.wait_in_text(".service-name", "MEMBLOB=")
 
-        b.go("/performance-graphs")
-        b.enter_page("/performance-graphs")
+        b.go("/metrics")
+        b.enter_page("/metrics")
         b.wait_present("table[aria-label='Top 5 memory services']")
 
         # use even more memory to trigger swap
@@ -445,8 +445,8 @@ class TestApplication(testlib.MachineCase):
         dev = m.execute("findmnt --noheadings -o SOURCE /var/cockpittest").strip()
         b.wait_in_text("#mounts", dev)
 
-        b.go("/performance-graphs")
-        b.enter_page("/performance-graphs")
+        b.go("/metrics")
+        b.enter_page("/metrics")
         b.wait_present(progress_sel)
         b.logout()
 
@@ -454,7 +454,7 @@ class TestApplication(testlib.MachineCase):
         self.restore_file("/usr/share/cockpit/storaged/manifest.json")
         m.write("/usr/share/cockpit/storaged/manifest.json", "")
         self.allow_journal_messages("storaged: couldn't read manifest.json: JSON data was empty")
-        b.login_and_go("/performance-graphs")
+        b.login_and_go("/metrics")
         b.wait_present(progress_sel)
         self.assertFalse(b.is_present("#current-disks-usage button"))
 
@@ -490,7 +490,7 @@ class TestMultiCPU(testlib.MachineCase):
         m = self.machine
 
         prepareArchive(m, "2corescpu.tar.gz", 1598971635)
-        self.login_and_go("/performance-graphs")
+        self.login_and_go("/metrics")
 
         # one core is busy, the other idle -- that should be 50% total usage
         self.assertGreaterEqual(getCompressedMinuteValue(b, "cpu", False, 1598968800000, 44), 0.2)


### PR DESCRIPTION
This fits better with the other page names, and avoids confusion with
the already existing "performance" manifest, which is tuned (and
probably also ought to be renamed..)